### PR TITLE
On/off toggle in lists for switches and lights

### DIFF
--- a/harbour-quartermaster.pro
+++ b/harbour-quartermaster.pro
@@ -85,6 +85,7 @@ DISTFILES += qml/harbour-quartermaster.qml \
     qml/pages/entities/EntitiesListViewPage.qml \
     qml/pages/entities/EntitiesOverviewPage.qml \
     qml/pages/entities/EntityAttributesPage.qml \
+    qml/pages/entities/LightsListPage.qml \
     qml/pages/entities/PersonsListPage.qml \
     qml/pages/entities/SensorsListPage.qml \
     qml/pages/entities/SwitchesListPage.qml \

--- a/harbour-quartermaster.pro
+++ b/harbour-quartermaster.pro
@@ -87,6 +87,7 @@ DISTFILES += qml/harbour-quartermaster.qml \
     qml/pages/entities/EntityAttributesPage.qml \
     qml/pages/entities/PersonsListPage.qml \
     qml/pages/entities/SensorsListPage.qml \
+    qml/pages/entities/SwitchesListPage.qml \
     qml/pages/entities/types/AutomationPage.qml \
     qml/pages/entities/types/CameraPage.qml \
     qml/pages/entities/types/ClimatePage.qml \

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -96,6 +96,10 @@ Page {
                 var page;
 
                 switch (type) {
+                case Entity.Light:
+                    page = "entities/LightsListPage.qml"
+                    break;
+
                 case Entity.Person:
                     page = "entities/PersonsListPage.qml"
                     break;

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -104,6 +104,10 @@ Page {
                     page = "entities/SensorsListPage.qml"
                     break;
 
+                case Entity.Switch:
+                    page = "entities/SwitchesListPage.qml"
+                    break;
+
                 default:
                     page = "entities/EntitiesListViewPage.qml"
                     break;

--- a/qml/pages/entities/LightsListPage.qml
+++ b/qml/pages/entities/LightsListPage.qml
@@ -1,0 +1,177 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+import org.nubecula.harbour.quartermaster 1.0
+
+import "../../components/"
+
+Page {
+    property bool busy: false
+    property string title
+    property int type
+    property string icon
+
+    id: page
+
+    allowedOrientations: Orientation.All
+
+    PageBusyIndicator {
+        id: busyIndicator
+        size: BusyIndicatorSize.Large
+        running: busy
+        anchors.centerIn: parent
+    }
+
+    SilicaFlickable {
+        PullDownMenu {
+            MenuItem {
+                text: qsTr("Refresh")
+                onClicked: {
+                    busy = true
+                    App.entitiesService().refresh()
+                }
+            }
+
+            MenuItem {
+                text: qsTr("Search")
+                onClicked: listView.showSearch = true
+            }
+        }
+
+        anchors.fill: parent
+
+        Column {
+            id: header
+            width: parent.width
+
+            PageHeader {
+                title: page.title
+            }
+
+            SearchField {
+                id: searchField
+                width: parent.width
+                height: listView.showSearch ? implicitHeight : 0
+                opacity: listView.showSearch ? 1 : 0
+                onTextChanged: {
+                    filterModel.setFilterFixedString(text)
+                }
+
+                Connections {
+                    target: listView
+                    onShowSearchChanged: {
+                        searchField.forceActiveFocus()
+                    }
+                }
+
+                Behavior on height {
+                    NumberAnimation { duration: 300 }
+                }
+                Behavior on opacity {
+                    NumberAnimation { duration: 300 }
+                }
+            }
+        }
+
+        SilicaListView {
+            property bool showSearch: false
+
+            id: listView
+
+            visible: !busyIndicator.running
+
+            width: parent.width
+            anchors.top: header.bottom
+            anchors.bottom: parent.bottom
+
+            clip: true
+
+            model: EntitiesSortFilterModel {
+                id: filterModel
+                sourceModel: App.entitiesService().entitiesModel()
+            }
+
+            delegate: ListItem {
+                id: delegate
+                width: parent.width
+                contentHeight: Theme.itemSizeMedium
+
+                Row {
+                    x: Theme.horizontalPageMargin
+                    width: parent.width - 2 * x
+                    height: parent.height
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: Theme.paddingMedium
+
+                    Image {
+                        id: itemIcon
+                        source: page.icon
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    Column {
+                        width: parent.width - itemIcon.width - Theme.paddingMedium
+                        anchors.verticalCenter: itemIcon.verticalCenter
+
+                        Label {
+                            width: parent.width
+                            text: name
+                            color: pressed ? Theme.secondaryHighlightColor : Theme.highlightColor
+                            font.pixelSize: Theme.fontSizeMedium
+                        }
+                        TextSwitch {
+                            text: {
+                                if (entityState === "on") {
+                                    return qsTr("on", "state")
+                                } else if (entityState === "off") {
+                                    return qsTr("off", "state")
+                                } else if (entityState === "unavailable") {
+                                    return qsTr("unavailable", "state")
+                                }
+                                return qsTr("undefined", "state")
+                            }
+                            checked: entityState === "on"
+                            enabled: entityState === "on" || entityState === "off"
+
+                            onClicked: {
+                                page.busy = true;
+                                App.entitiesService().callService("light",
+                                                                  checked ? "turn_on" : "turn_off",
+                                                                  entityId)
+                            }
+                        }
+                    }
+                }
+
+                onClicked: pageStack.push(Qt.resolvedUrl("types/LightPage.qml"),
+                                          { entity: filterModel.entityAt(index) })
+            }
+
+            ViewPlaceholder {
+                enabled: listView.count == 0
+                text: qsTr("No entities available")
+                hintText: qsTr("Check your network connection")
+            }
+
+            VerticalScrollDecorator {}
+        }
+    }
+
+    Component.onCompleted: {
+        filterModel.resetEntityFilter()
+        filterModel.addEntityFilter(type)
+    }
+
+    Component.onDestruction: filterModel.resetEntityFilter()
+
+    Connections {
+        target: App.api()
+        onRequestFinished: {
+            if (requestType === Api.RequestGetApiStates) {
+                busy = false
+            } else if (requestType === Api.RequestPostApiServices) {
+                App.entitiesService().refresh()
+            }
+        }
+    }
+}

--- a/qml/pages/entities/SwitchesListPage.qml
+++ b/qml/pages/entities/SwitchesListPage.qml
@@ -1,0 +1,177 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+import org.nubecula.harbour.quartermaster 1.0
+
+import "../../components/"
+
+Page {
+    property bool busy: false
+    property string title
+    property int type
+    property string icon
+
+    id: page
+
+    allowedOrientations: Orientation.All
+
+    PageBusyIndicator {
+        id: busyIndicator
+        size: BusyIndicatorSize.Large
+        running: busy
+        anchors.centerIn: parent
+    }
+
+    SilicaFlickable {
+        PullDownMenu {
+            MenuItem {
+                text: qsTr("Refresh")
+                onClicked: {
+                    busy = true
+                    App.entitiesService().refresh()
+                }
+            }
+
+            MenuItem {
+                text: qsTr("Search")
+                onClicked: listView.showSearch = true
+            }
+        }
+
+        anchors.fill: parent
+
+        Column {
+            id: header
+            width: parent.width
+
+            PageHeader {
+                title: page.title
+            }
+
+            SearchField {
+                id: searchField
+                width: parent.width
+                height: listView.showSearch ? implicitHeight : 0
+                opacity: listView.showSearch ? 1 : 0
+                onTextChanged: {
+                    filterModel.setFilterFixedString(text)
+                }
+
+                Connections {
+                    target: listView
+                    onShowSearchChanged: {
+                        searchField.forceActiveFocus()
+                    }
+                }
+
+                Behavior on height {
+                    NumberAnimation { duration: 300 }
+                }
+                Behavior on opacity {
+                    NumberAnimation { duration: 300 }
+                }
+            }
+        }
+
+        SilicaListView {
+            property bool showSearch: false
+
+            id: listView
+
+            visible: !busyIndicator.running
+
+            width: parent.width
+            anchors.top: header.bottom
+            anchors.bottom: parent.bottom
+
+            clip: true
+
+            model: EntitiesSortFilterModel {
+                id: filterModel
+                sourceModel: App.entitiesService().entitiesModel()
+            }
+
+            delegate: ListItem {
+                id: delegate
+                width: parent.width
+                contentHeight: Theme.itemSizeMedium
+
+                Row {
+                    x: Theme.horizontalPageMargin
+                    width: parent.width - 2 * x
+                    height: parent.height
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: Theme.paddingMedium
+
+                    Image {
+                        id: itemIcon
+                        source: page.icon
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    Column {
+                        width: parent.width - itemIcon.width - Theme.paddingMedium
+                        anchors.verticalCenter: itemIcon.verticalCenter
+
+                        Label {
+                            width: parent.width
+                            text: name
+                            color: pressed ? Theme.secondaryHighlightColor : Theme.highlightColor
+                            font.pixelSize: Theme.fontSizeMedium
+                        }
+                        TextSwitch {
+                            text: {
+                                if (entityState === "on") {
+                                    return qsTr("on", "state")
+                                } else if (entityState === "off") {
+                                    return qsTr("off", "state")
+                                } else if (entityState === "unavailable") {
+                                    return qsTr("unavailable", "state")
+                                }
+                                return qsTr("undefined", "state")
+                            }
+                            checked: entityState === "on"
+                            enabled: entityState === "on" || entityState === "off"
+
+                            onClicked: {
+                                page.busy = true;
+                                App.entitiesService().callService("switch",
+                                                                  checked ? "turn_on" : "turn_off",
+                                                                  entityId)
+                            }
+                        }
+                    }
+                }
+
+                onClicked: pageStack.push(Qt.resolvedUrl("types/SwitchPage.qml"),
+                                          { entity: filterModel.entityAt(index) })
+            }
+
+            ViewPlaceholder {
+                enabled: listView.count == 0
+                text: qsTr("No entities available")
+                hintText: qsTr("Check your network connection")
+            }
+
+            VerticalScrollDecorator {}
+        }
+    }
+
+    Component.onCompleted: {
+        filterModel.resetEntityFilter()
+        filterModel.addEntityFilter(type)
+    }
+
+    Component.onDestruction: filterModel.resetEntityFilter()
+
+    Connections {
+        target: App.api()
+        onRequestFinished: {
+            if (requestType === Api.RequestGetApiStates) {
+                busy = false
+            } else if (requestType === Api.RequestPostApiServices) {
+                App.entitiesService().refresh()
+            }
+        }
+    }
+}

--- a/translations/harbour-quartermaster-de.ts
+++ b/translations/harbour-quartermaster-de.ts
@@ -375,6 +375,45 @@
     </message>
 </context>
 <context>
+    <name>LightsListPage</name>
+    <message>
+        <source>Refresh</source>
+        <translation>Aktualisieren</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation>Suche</translation>
+    </message>
+    <message>
+        <source>on</source>
+        <comment>state</comment>
+        <translation>an</translation>
+    </message>
+    <message>
+        <source>off</source>
+        <comment>state</comment>
+        <translation>aus</translation>
+    </message>
+    <message>
+        <source>unavailable</source>
+        <comment>state</comment>
+        <translation>nicht verfügbar</translation>
+    </message>
+    <message>
+        <source>undefined</source>
+        <comment>state</comment>
+        <translation>undefiniert</translation>
+    </message>
+    <message>
+        <source>No entities available</source>
+        <translation>Keine Entitäten verfügbar</translation>
+    </message>
+    <message>
+        <source>Check your network connection</source>
+        <translation>Netzwerkverbindung überprüfen</translation>
+    </message>
+</context>
+<context>
     <name>NotificationService</name>
     <message>
         <source>There is an update to version %1 available.</source>

--- a/translations/harbour-quartermaster-de.ts
+++ b/translations/harbour-quartermaster-de.ts
@@ -1125,6 +1125,45 @@
     </message>
 </context>
 <context>
+    <name>SwitchesListPage</name>
+    <message>
+        <source>Refresh</source>
+        <translation>Aktualisieren</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation>Suche</translation>
+    </message>
+    <message>
+        <source>No entities available</source>
+        <translation>Keine Entitäten verfügbar</translation>
+    </message>
+    <message>
+        <source>Check your network connection</source>
+        <translation>Netzwerkverbindung überprüfen</translation>
+    </message>
+    <message>
+        <source>on</source>
+        <comment>state</comment>
+        <translation>an</translation>
+    </message>
+    <message>
+        <source>off</source>
+        <comment>state</comment>
+        <translation>aus</translation>
+    </message>
+    <message>
+        <source>unavailable</source>
+        <comment>state</comment>
+        <translation>nicht verfügbar</translation>
+    </message>
+    <message>
+        <source>undefined</source>
+        <comment>state</comment>
+        <translation>undefiniert</translation>
+    </message>
+</context>
+<context>
     <name>TestResultItem</name>
     <message>
         <source>FAILED</source>

--- a/translations/harbour-quartermaster.ts
+++ b/translations/harbour-quartermaster.ts
@@ -1122,6 +1122,45 @@
     </message>
 </context>
 <context>
+    <name>SwitchesListPage</name>
+    <message>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No entities available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <comment>state</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <comment>state</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>unavailable</source>
+        <comment>state</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>undefined</source>
+        <comment>state</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TestResultItem</name>
     <message>
         <source>FAILED</source>

--- a/translations/harbour-quartermaster.ts
+++ b/translations/harbour-quartermaster.ts
@@ -374,6 +374,45 @@
     </message>
 </context>
 <context>
+    <name>LightsListPage</name>
+    <message>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <comment>state</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <comment>state</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>unavailable</source>
+        <comment>state</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>undefined</source>
+        <comment>state</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No entities available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>NotificationService</name>
     <message>
         <source>There is an update to version %1 available.</source>


### PR DESCRIPTION
To me switching many lights/switches on or off felt quite tedious: Going to a list, pressing the entity to go to its page, pressing the toggle button there, then navigating back to the list to go the next entity. I added the toggle buttons directly to the entries in the lists by creating new type-specific list views.

I still see two problems with the changes proposed here and like to hear your opinion:
* There is much code duplication. It would be nice if commonly used QML parts could be refactored into a common list view. I have nearly no experience with QML and would like to hear suggestions on how to achieve that.
* The vertical placement of the new list entries looks a little bit off, especially in direct comparison with the old ones. Maybe the height of the `TextSwitch` could be decreased somehow.

Lights list, German locale, before and after this PR:
![quartermaster-lights-before](https://user-images.githubusercontent.com/1190698/144621868-59de7904-11bf-48c9-b557-193c564015a4.png) ![quartermaster-lights-after](https://user-images.githubusercontent.com/1190698/144621862-34b50e14-c2aa-4126-ab5d-cfefc634a77e.png) 

Switches list, German locale, before and after this PR:
![quartermaster-switches-before](https://user-images.githubusercontent.com/1190698/144621871-6b17bdde-4fbd-4a7e-a609-87698407e2c5.png) ![quartermaster-switches-after](https://user-images.githubusercontent.com/1190698/144621870-16b5b38b-1ac8-446d-a5df-63824802b7c0.png)

